### PR TITLE
Fix regex in `org-wiki--page-files`

### DIFF
--- a/org-wiki.el
+++ b/org-wiki.el
@@ -226,7 +226,7 @@ ELISP> (remove-if-not #'file->org-wiki/page (org-wiki/page-files))
              (string-prefix-p "#" b)
              (string-suffix-p "#" b)
            ))))
-   (directory-files org-wiki-location abspath ".org")))
+   (directory-files org-wiki-location abspath "\\.org$")))
 
 
 (defun org-wiki--page-list ()


### PR DESCRIPTION
So that asset directories with, e.g. `-org` in the name are not matched.

Before:

```
ELISP> (-contains? (org-wiki--page-files) "ref-emacs-orgmode-notes")
t
```

After:

```
ELISP> (-contains? (org-wiki--page-files) "ref-emacs-orgmode-notes")
nil
```