### PR TITLE
Update Readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,7 +22,6 @@ name ~keyword.org~.
 
 | Repository         | https://github.com/caiorss/org-wiki |
 | Html documentation | https://caiorss.github.io/org-wiki/ |
-|                    |                                     |
  
 *Features:*
 
@@ -32,8 +31,8 @@ name ~keyword.org~.
 
   - Create new wiki pages fast.
 
-  - Command to export all pages to html without block Emacs. M-x =M-x
-    org-wiki/export-html-async=
+  - Command to export all pages to html without block Emacs.
+    =M-x org-wiki/export-html-async=
 
   - Search wiki pages by its content. (grep)
 
@@ -132,21 +131,21 @@ You can see Org-mode Screencasts and reviews here:
 
 ** Demos 
 
- - (1) Browsing Index: M-x org-wiki/index
+ - (1) Browsing Index: =M-x org-wiki/index=
 
 [[file:images/org-wiki-index.gif][file:images/org-wiki-index.gif]]
 
 
- - (2) M-x org-wiki/helm - Select a wiki page by name. 
+ - (2) =M-x org-wiki/helm= - Select a wiki page by name. 
 
 [[file:images/org-wiki-helm.gif][file:images/org-wiki-helm.gif]]
 
- - (3) M-x org-wiki/insert  Insert a link to wiki page at cursor position.
+ - (3) =M-x org-wiki/insert=  Insert a link to wiki page at cursor position.
 
 [[file:images/org-wiki-insert.gif][file:images/org-wiki-insert.gif]]
 
 
- - (4) - M-x org-wiki/asset-insert Insert a link to a asset file that
+ - (4) - =M-x org-wiki/asset-insert= Insert a link to a asset file that
    when clicked opens it with default system application.
 
 See video: [[http://i.imgur.com/KqqC7sY.mp4][M-x org-wiki/asset-insert]]
@@ -191,10 +190,10 @@ You can view a sample wiki exported to html here:
 
 [[file:images/wiki-dired-all.png][file:images/wiki-dired-all.png]]
 
- - 6. =M-x org-wiki-search-pattern= Search for all wiki page that contains
+ - 6. =M-x org-wiki/search-pattern= Search for all wiki pages that contains
    a pattern. (string or regex pattern). 
 
-Example: The command =M-x org-wiki/search-patern - System.Windows= will search all
+Example: The command =M-x org-wiki/search-pattern - System.Windows= will search all
 files that contains "System.Windows string".
 
 [[file:images/wiki-search-pattern.png][file:images/wiki-search-pattern.png]]
@@ -210,7 +209,7 @@ one wiki can be used at a time. So, to switch wiki type:
 
 To create a page do:
 
- - 1. M-x org-wiki-index - It goes to the Org-wiki index page
+ - 1. =M-x org-wiki-index= - It goes to the Org-wiki index page
    (index.org).
 
  - 2. Then run =M-x org-wiki-insert-new= and a page name like 'CNC - Computer Numerical Control'
@@ -221,7 +220,7 @@ It will insert a hyperlink at point like:
  [[wiki:CNC%20-%20Computer%20Numerical%20Control][CNC - Computer Numerical Control]]
 #+END_SRC
 
- - 3. Then click at the link or enter C-x C-o at the link to open it.
+ - 3. Then click at the link or enter =C-x C-o= at the link to open it.
 
 *** Create a page - way 2
 
@@ -343,7 +342,7 @@ The default value of this variable is
 
 In Windows it can be: 
 
- - Note: backward slash in path \, must be escaped as \\
+ - Note: backward slash in path =\=, must be escaped as =\\=
 
 #+BEGIN_SRC elisp 
 ;; (setq org-wiki-location "e:/projects/org-wiki-test.emacs")
@@ -363,7 +362,7 @@ org-wiki pages are opened in read-only mode. The default value of this
 variable is nil (false). It is useful to avoid unintended and
 accidental changings an org-wiki page.
 
-The read-only mode can be toggled with =M-x toggle-read-only= or C-x C-q.
+The read-only mode can be toggled with =M-x toggle-read-only= or =C-x C-q=.
 
  - Open org-wiki pages in read-only mode. 
 
@@ -491,7 +490,7 @@ This variable can also be set programatically with:
 
 *** Start the wiki 
 
- - M-x org-wiki-index to go to index.org
+ - =M-x org-wiki-index= to go to index.org
 
  - New pages can be created with =M-x org-wiki-link= that asks for
    wiki word and inserts at point a hyperlink to the wiki page.
@@ -518,7 +517,6 @@ This variable can also be set programatically with:
 | org-wiki-helm                   | Open a org-wiki page                                                                              |
 | org-wiki-helm-frame             | Open a org-wiki page in a new frame                                                               |
 | org-wiki-helm-read-only         | Open a org-wiki page in read-only mode                                                            |
-|                                 |                                                                                                   |
 |                                 |                                                                                                   |
 | *Close Command*                 |                                                                                                   |
 |---------------------------------+---------------------------------------------------------------------------------------------------|
@@ -561,7 +559,6 @@ This variable can also be set programatically with:
 | org-wiki-toggle-link            | Toggle link display. Alias to M-x org-toggle-link-display.                                        |
 | org-wiki-latex                  | Display latex formulas. Alias to org-preview-latex-fragment. Requires latex installed.            |
 |                                 |                                                                                                   |
-|                                 |                                                                                                   |
 | *Backup Command*                |                                                                                                   |
 | org-wiki-backup-make            | Create new zip file backup of all org-wiki files.                                                 |
 | org-wiki-backup-dir             | Open backup directory.                                                                            |
@@ -571,8 +568,6 @@ This variable can also be set programatically with:
 | org-wiki-panel                  | A panel like magit-status panel.                                                                  |
 | org-wiki-server-toggle          | Toggle Python web server.                                                                         |
 | org-wiki-make-menu              | Install an org-wiki menu.                                                                         |
-|                                 |                                                                                                   |
-|                                 |                                                                                                   |
 
 Not complete yet.
 
@@ -636,7 +631,7 @@ Not complete yet.
  
 Example: 
 
- - 1. User enter M-x org-wiki-link and enter "The Art of Unix Programming"
+ - 1. User enter =M-x org-wiki-link= and enter "The Art of Unix Programming"
  - 2. It will insert at point (current cursor position):
 
 #+BEGIN_SRC txt
@@ -647,7 +642,7 @@ And will create the hyperlink to this page.
 
 **** M-x org-wiki-header 
 
- - =M-x org-wiki-header. It inserts at top of the wiki page the template:
+ - =M-x org-wiki-header=. It inserts at top of the wiki page the template:
 
 #+BEGIN_SRC txt
 #+TITLE: <PAGE TITLE>
@@ -684,8 +679,8 @@ Open page's asset directory in Emacs dired mode.
 ***** M-x org-wiki-asset-create
 
 Prompts the user for a file name that doesn't exist yet and insert it
-at point.  Unlike the commands `org-wiki-asset-insert` or `
-org-wiki-asset-insert-file` this command asks the user for a file that
+at point.  Unlike the commands =org-wiki-asset-insert= or
+=org-wiki-asset-insert-file= this command asks the user for a file that
 doesn't exist yet and inserts a hyperlink to it at point. 
 
 Example: If the user enter this command and he is in the page Linux
@@ -819,7 +814,7 @@ Example:
  2. User copy the url
     <https://inst.eecs.berkeley.edu/~cs61b/fa13/ta-materials/unix-concise-ref.pdf>
 
- 3. User enter M-x org-wiki-asset-download-insert1
+ 3. User enter =M-x org-wiki-asset-download-insert1=
     1. Confirm the first prompt asking for the url. The suggested url is the copied url.
     2. Confirm the second prompt asking the file name. The suggested
        name is unix-concise-ref.pdf
@@ -833,7 +828,7 @@ Example:
 
 
 Note: This command is synchronous and it can hang Emacs, therefore
-downloading heavy files can freeze Emacs. If it happesn type C-g to
+downloading heavy files can freeze Emacs. If it happesn type =C-g= to
 cancel the current download.
 
 ***** M-x org-wiki-asset-download-insert2
@@ -847,7 +842,7 @@ Example:
   1. User is in the page Linux and copies the url:
      ~http://i1-linux.softpedia-static.com/screenshots/htop_1.jpg~
 
-  2. User enter the command M-x org-wiki-asset-download-insert1 and
+  2. User enter the command =M-x org-wiki-asset-download-insert2= and
      answers all prompts.
 
   3. It will insert the hyperlink bellow at point. 
@@ -1302,9 +1297,9 @@ the function is defined and edit the file org-wiki.el.
 
 Example: 
  
- - M-x find-function =org-wiki-helm=
+ - =M-x find-function org-wiki-helm=
 
- - M-x find-library org-wiki
+ - =M-x find-library org-wiki=
 
 ** TODOLIST 
 


### PR DESCRIPTION
Overview section:
- Remove the empty last table row

Features section:
- Removed duplicate M-x.
- Moved both the key binding and command to the second line.
Github still shows the comment and key binding/command on a
single line, but it's easier to read in the readme.org file,
when M-x is on the same line as the command.

Demos section:
- Added verbatim emphasis (equal signs) around M-x commands.

Screenshots section:
- Update renamed command (dash to slash):
=M-x org-wiki-search-pattern= -> =M-x org-wiki/search-pattern=
- Missing `s` after `page`
6. =M-x org-wiki-search-pattern= Search for all wiki page that contains
   a pattern. (string or regex pattern).
- Missing `t` in `patern` in: `=M-x org-wiki/search-patern - System.Windows=

Workflow section:
- Added verbatim emphasis around M-x commands and a key binding.

Configuration section:
- Added verbatim emphasis around the single and double backslashes
(double backslashes were not visible on github).

Open org-wiki pages in read-only section:
- Added verbatim emphasis around a key binding.

Start the wiki section:
- Added verbatim emphasis around M-x command.

Command Summary section:
- Reduced double empty table rows to a single row between the sections:
  - Navigation and Close Command
  - Alias Command and Backup Command
- And removed the two empty table rows at the end of the Misc section.

M-x org-wiki-insert-link section:
- Added verbatim emphasis around M-x command.

M-x org-wiki-header section:
- Added missing closing verbatim emphasis sign.

M-x org-wiki-asset-create section:
- Changed (backticks/grave accent characters) around commands to verbatim emphasis.

M-x org-wiki-asset-download-insert1 section:
- Added verbatim emphasis around M-x command and a key binding.
- Fixed typo: happesn -> happens

M-x org-wiki-asset-download-insert2 section:
- Added verbatim emphasis around M-x command.
- Changed the command ending in a 1 to end in a 2:
M-x org-wiki-asset-download-insert1 -> M-x org-wiki-asset-download-insert2
Since it's in the org-wiki-asset-download-insert2 section the command probably
should use the command ending in a `2`.

Modify it section:
- Added verbatim emphasis around M-x commands.